### PR TITLE
User Experience: Allow users to add Description to Private Gateway an…

### DIFF
--- a/ui/src/views/network/VpcTab.vue
+++ b/ui/src/views/network/VpcTab.vue
@@ -224,6 +224,16 @@
                   v-model:value="form.netmask"
                 ></a-input>
               </a-form-item>
+              <a-form-item :label="$t('label.description')" ref="description" name="description">
+                <a-textarea
+                  :placeholder="placeholder.description"
+                  v-model="form.description"
+                  auto-size="{
+                    minRows: 2,
+                    maxRows: 5
+                  }"
+                ></a-textarea>
+              </a-form-item>
               <a-form-item :label="$t('label.sourcenat')" ref="nat" name="nat">
                 <a-checkbox v-model:checked="form.nat"></a-checkbox>
               </a-form-item>
@@ -433,7 +443,8 @@ export default {
         vlan: null,
         ipaddress: null,
         gateway: null,
-        netmask: null
+        netmask: null,
+        description: null
       },
       physicalnetworks: [],
       vpncustomergateways: [],
@@ -459,6 +470,11 @@ export default {
         {
           title: this.$t('label.vlan'),
           dataIndex: 'vlan'
+        },
+        {
+          key: 'description',
+          title: this.$t('label.description'),
+          dataIndex: 'description'
         }
       ],
       vpnConnectionsColumns: [


### PR DESCRIPTION
### Description

This PR introduces the ability to add descriptions to Private Gateways and Static Routes within the CloudStack UI. The enhancement aims to improve the maintainability and clarity of network configurations as users scale up the number of gateways and routes. Currently, the UI lacks a way to note what each gateway or route is intended for, leading to confusion especially in environments with multiple administrators. By allowing users to annotate their configurations, this update will make it easier to understand and manage network setups.

Fixes: # 8837

### Types of changes

- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Enhancement (improves an existing feature and functionality)
- [ ] Cleanup (Code refactoring and cleanup, that may add test cases)
- [ ] build/CI

### Feature/Enhancement Scale or Bug Severity

#### Feature/Enhancement Scale

- [x] Minor

### Screenshots (if appropriate):

<img width="629" alt="Screenshot 2024-05-21 at 12 06 36 PM" src="https://github.com/my-code-AL/cloudstack/assets/110478358/54d0cb29-a167-403f-8834-3b60fa9078ad">


### How Has This Been Tested?

This feature was tested on CloudStack 4.19, using multiple configurations of Private Gateways and Static Routes. I created several scenarios with varying numbers of gateways and routes to ensure the description fields are visible and functional across different setups. Additional tests were performed to verify that the descriptions persist after edits and are visible to all users with appropriate permissions.

#### How did you try to break this feature and the system with this change?

Tests included attempting to input excessively long descriptions, special characters, and HTML tags to ensure input validation is properly handled. I also tested the feature's interaction with existing functionalities such as the creation and deletion of gateways and routes to ensure there are no regressions.

Please read the [CONTRIBUTING](https://github.com/apache/cloudstack/blob/main/CONTRIBUTING.md) document for more details on contributing to CloudStack.


